### PR TITLE
support IPv6 DNS servers

### DIFF
--- a/cmd/dnscouch/main.go
+++ b/cmd/dnscouch/main.go
@@ -10,14 +10,19 @@ import (
 
 func main() {
 	n := flag.Int("c", 1, "count - number of lookups to make per server")
+	useIPv6 := flag.Bool("6", false, "query IPv6 servers (DNS only)")
 	flag.Parse()
+	dnsServers := dnscouch.ServerMap4
+	if *useIPv6 {
+		dnsServers = dnscouch.ServerMap6
+	}
 	for i := 0; i < *n; i++ {
-		times, err := dnscouch.TimeDNSLookupServers()
+		times, err := dnscouch.TimeDNSLookupServers(dnsServers)
 		if err != nil {
 			log.Print("error:", err)
 		}
 		for server, t := range times {
-			desc := dnscouch.ServerMap[server]
+			desc := dnsServers[server]
 			fmt.Printf("%d, %v %v %v\n", i, t, server, desc)
 		}
 	}

--- a/cmd/dnscouchT/main.go
+++ b/cmd/dnscouchT/main.go
@@ -53,6 +53,7 @@ func (m model) View() string {
 func main() {
 	n := flag.Int("c", 1, "count - number of lookups to make per server")
 	tf := flag.Bool("t", false, "query NTP servers instead of DNS servers")
+	useIPv6 := flag.Bool("6", false, "query IPv6 servers (DNS only)")
 	flag.Parse()
 	columns := []table.Column{
 		{Title: "RTT", Width: 8},
@@ -63,7 +64,11 @@ func main() {
 	var rh int
 	switch *tf {
 	case false:
-		rs, err := dnscouch.LookupServersN(*n)
+		dnsServers := dnscouch.ServerMap4
+		if *useIPv6 {
+			dnsServers = dnscouch.ServerMap6
+		}
+		rs, err := dnscouch.LookupServersN(dnsServers, *n)
 		if err != nil {
 			log.Print("error:", err)
 		}


### PR DESCRIPTION
A list of IPv6 addresses to DNS servers is included, and used when the -6 flag
is specified. Works for DNS only right now (no support for NTP servers).